### PR TITLE
fix: 有 unpushed commits 时 PullToLatestField 显示 disabled branch selector 而不是隐藏

### DIFF
--- a/frontend/components/shared/pull-to-latest-field.tsx
+++ b/frontend/components/shared/pull-to-latest-field.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Field, FieldLabel, FieldDescription } from '@/components/ui/field'
 import { Switch } from '@/components/ui/switch'
@@ -36,24 +37,41 @@ export function PullToLatestField({
 }: PullToLatestFieldProps) {
   const { t } = useTranslation('tasks')
 
+  const blockedByUnpushed = unpushedCommits > 0
+  const toggleDisabled = disabled || blockedByUnpushed
+
+  // Avoid the "ON but rejected" third state — if the user had pullToLatest=true
+  // and a switch in the source repo introduces unpushed commits, force it back
+  // to OFF so submit reads a coherent value.
+  useEffect(() => {
+    if (blockedByUnpushed && pullToLatest) {
+      onPullToLatestChange(false)
+    }
+  }, [blockedByUnpushed, pullToLatest, onPullToLatestChange])
+
   if (remoteBranches.length === 0) return null
 
   return (
-    <Field>
-      <div className="flex items-center justify-between">
+    <Field data-disabled={toggleDisabled || undefined}>
+      <div
+        className="flex items-center justify-between"
+        title={blockedByUnpushed ? t('createModal.pullToLatestBlockedByUnpushed', { count: unpushedCommits, branch: baseBranch }) : undefined}
+      >
         <FieldLabel>{t('createModal.pullToLatest')}</FieldLabel>
         <Switch
-          checked={pullToLatest}
+          checked={pullToLatest && !blockedByUnpushed}
           onCheckedChange={onPullToLatestChange}
+          disabled={toggleDisabled}
+          aria-disabled={toggleDisabled}
           size="sm"
         />
       </div>
-      {pullToLatest && unpushedCommits > 0 && (
+      {blockedByUnpushed && (
         <p className="text-sm text-destructive">
           {t('createModal.pullToLatestBlockedByUnpushed', { count: unpushedCommits, branch: baseBranch })}
         </p>
       )}
-      {pullToLatest && !unpushedCommits && (
+      {pullToLatest && !blockedByUnpushed && (
         <Select
           value={pullRemoteBranch}
           onValueChange={(v) => onPullRemoteBranchChange(v ?? '')}
@@ -77,7 +95,7 @@ export function PullToLatestField({
           </SelectContent>
         </Select>
       )}
-      {pullToLatest && !unpushedCommits && (
+      {pullToLatest && !blockedByUnpushed && (
         <FieldDescription>{t('createModal.pullToLatestHint')}</FieldDescription>
       )}
       {uncommittedFiles > 0 && (


### PR DESCRIPTION
Closes #32

## 摘要

`PullToLatestField` 之前在源 repo 有 unpushed commits 时把 branch selector 隐藏。第一轮改成 disabled selector + 红色文案，但 reviewer 指出 toggle 是 ON（蓝色）+ selector disabled + 红字说不能用——是 "ON 但被拒绝" 的混合第三态，跟用户心智模型直接冲突。

第二轮改成跟 #54 的 no-remote 处理对称：toggle 也 disabled，跟"无法启用"语义一致。useEffect 把 stale `pullToLatest=true` 强制设回 false。

## 变更预演（Layer 1）

不适用 — 前端渲染分支调整。

## 落地核对（Layer 2）

```
$ bunx eslint frontend/components/shared/pull-to-latest-field.tsx
LINT=0
$ bunx tsc --noEmit
TSC=0
```

## 启动 / 运行时顺序（Layer 3）

不适用。

## 端到端业务行为（Layer 4）

`agent-browser` 选 `unpushed` fixture（base + 1 unpushed commit）。

modal 全图：

![PR55 v2 — modal with red unpushed warning](https://raw.githubusercontent.com/Mouriya-Emma/fulcrum/0065a089d7c62c8a3402193b2f511da96d9ff16f/screenshots/e2e-evidence/pr-55-v2-toggle-disabled-unpushed.png)

Pull to Latest 区域 close-up：

![PR55 v2 — close-up: toggle disabled OFF + red unpushed text](https://raw.githubusercontent.com/Mouriya-Emma/fulcrum/0065a089d7c62c8a3402193b2f511da96d9ff16f/screenshots/e2e-evidence/pr-55-v2-toggle-disabled-closeup.png)

可见 v2 的 "Pull to Latest" 行：label 淡化、toggle disabled OFF（不再像 v1 是 ON 蓝色 + selector disabled 的混合第三态），下方红字 **"1 unpushed commit(s) on \"main\" — push first to use Pull to Latest"**。selector 不再渲染（toggle OFF + blocked → 整个 selector + hint 收起），用户的"toggle ON = 启用"心智模型不再被违反。

## Analysis

PR #54（无 remote）+ PR #55（有 remote 但 unpushed）现在共享对称语义：toggle 不可拨 ON 时一定 visually disabled，下面红字/灰字解释原因。useEffect 在 blockedByUnpushed 变 true 时强制 onPullToLatestChange(false)，避免 form state 跟视觉脱节。

via [HAPI](https://hapi.run)