### PR TITLE
feat: task detail 显示派生子任务反向列表

### DIFF
--- a/frontend/components/task/derived-tasks-list.tsx
+++ b/frontend/components/task/derived-tasks-list.tsx
@@ -1,0 +1,76 @@
+import { Link } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { GitForkIcon } from '@hugeicons/core-free-icons'
+import { useTasks } from '@/hooks/use-tasks'
+import type { Task } from '@/types'
+
+// Mounted in two render paths that are mutually exclusive by task type:
+//   - manual / draft → ManualTaskView (via task-content.tsx)
+//   - worktree / scratch → TaskDetailsPanel (via routes/tasks/$taskId.tsx)
+// No task state hits both, so the list never renders twice.
+
+interface DerivedTasksListProps {
+  taskId: string
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  TO_DO: 'bg-muted text-muted-foreground',
+  IN_PROGRESS: 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
+  IN_REVIEW: 'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+  DONE: 'bg-green-100 text-green-700 dark:bg-green-950/40 dark:text-green-300',
+  CANCELED: 'bg-muted text-muted-foreground line-through',
+}
+
+// Active-first then most-recent first: blockers / in-flight work surface above
+// DONE/CANCELED, so user notices what's still gating the parent.
+const STATUS_ORDER: Record<string, number> = {
+  IN_PROGRESS: 0,
+  IN_REVIEW: 1,
+  TO_DO: 2,
+  DONE: 3,
+  CANCELED: 4,
+}
+
+function compareDerived(a: Task, b: Task): number {
+  const orderDiff = (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99)
+  if (orderDiff !== 0) return orderDiff
+  return (b.createdAt ?? '').localeCompare(a.createdAt ?? '')
+}
+
+export function DerivedTasksList({ taskId }: DerivedTasksListProps) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const { data: allTasks } = useTasks()
+  const children = (allTasks ?? [])
+    .filter((task) => task.derivedFromTaskId === taskId)
+    .slice()
+    .sort(compareDerived)
+
+  if (children.length === 0) return null
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <h3 className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground mb-2">
+        <HugeiconsIcon icon={GitForkIcon} size={14} className="text-purple-600 dark:text-purple-400" />
+        {t('derivedTasks.heading', { count: children.length })}
+      </h3>
+      <ul className="flex flex-col gap-1.5">
+        {children.map((child) => (
+          <li key={child.id} className="flex items-center gap-2 text-sm">
+            <Link
+              to="/tasks/$taskId"
+              params={{ taskId: child.id }}
+              className="truncate hover:underline flex-1"
+            >
+              {child.title}
+            </Link>
+            <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${STATUS_CLASS[child.status] ?? STATUS_CLASS.TO_DO}`}>
+              {tc(`statuses.${child.status}`)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/components/task/task-content.tsx
+++ b/frontend/components/task/task-content.tsx
@@ -7,6 +7,7 @@ import { TimeEstimatePicker } from '@/components/task/time-estimate-picker'
 import { LinksManager } from '@/components/task/links-manager'
 import { DependencyManager } from '@/components/task/dependency-manager'
 import { DerivedFromBadge } from '@/components/task/derived-from-badge'
+import { DerivedTasksList } from '@/components/task/derived-tasks-list'
 import { AttachmentsManager } from '@/components/task/attachments-manager'
 import { WorktreeTaskSettings } from '@/components/task/worktree-task-settings'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -592,6 +593,9 @@ export function TaskContent({ task, onDeleted, compact }: TaskContentProps) {
 
           {/* Derived from */}
           {task.derivedFromTaskId && <DerivedFromBadge taskId={task.derivedFromTaskId} />}
+
+          {/* Derived tasks (reverse-lookup) */}
+          <DerivedTasksList taskId={task.id} />
 
           {/* Dependencies */}
           <div className={`rounded-lg border bg-card ${paddingClass}`}>

--- a/frontend/components/task/task-details-panel.tsx
+++ b/frontend/components/task/task-details-panel.tsx
@@ -19,6 +19,7 @@ import { PriorityPicker } from '@/components/task/priority-picker'
 import { LinksManager } from '@/components/task/links-manager'
 import { DependencyManager } from '@/components/task/dependency-manager'
 import { DerivedFromBadge } from '@/components/task/derived-from-badge'
+import { DerivedTasksList } from '@/components/task/derived-tasks-list'
 import { AttachmentsManager } from '@/components/task/attachments-manager'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Cancel01Icon, GitPullRequestIcon, Link02Icon, Loading03Icon, LockIcon } from '@hugeicons/core-free-icons'
@@ -517,6 +518,9 @@ export function TaskDetailsPanel({ task }: TaskDetailsPanelProps) {
 
         {/* Derived from */}
         {task.derivedFromTaskId && <DerivedFromBadge taskId={task.derivedFromTaskId} />}
+
+        {/* Derived tasks (reverse-lookup) */}
+        <DerivedTasksList taskId={task.id} />
 
         {/* Dependencies */}
         <div className="rounded-lg border bg-card p-4">

--- a/frontend/i18n/locales/en/tasks.json
+++ b/frontend/i18n/locales/en/tasks.json
@@ -143,6 +143,9 @@
     "derivedFromUnknown": "Derived from another task",
     "derivedLabel": "derived"
   },
+  "derivedTasks": {
+    "heading": "Derived tasks ({{count}})"
+  },
   "initializeModal": {
     "title": "Initialize as Worktree Task",
     "description": "Create a git worktree and start a coding session for \"{{taskTitle}}\"",

--- a/frontend/i18n/locales/zh/tasks.json
+++ b/frontend/i18n/locales/zh/tasks.json
@@ -143,6 +143,9 @@
     "derivedFromUnknown": "派生自其他任务",
     "derivedLabel": "派生"
   },
+  "derivedTasks": {
+    "heading": "派生任务（{{count}}）"
+  },
   "initializeModal": {
     "title": "初始化为工作树任务",
     "description": "为 \"{{taskTitle}}\" 创建 Git 工作树并开始编码会话",

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -329,6 +329,24 @@ app.post('/', async (c) => {
       if (parentTask.status === 'DONE' || parentTask.status === 'CANCELED') {
         return c.json({ error: `Cannot derive from a ${parentTask.status} task` }, 400)
       }
+      // Cycle defense: walk parent's chain. The new task's id is fresh so it
+      // cannot already appear, but if a future migration ever lets PATCH set
+      // derivedFromTaskId we'd want this here regardless. Bound the walk by
+      // visited set to avoid loops in pre-existing data.
+      const visited = new Set<string>([newTask.id])
+      let cursor: string | null = body.derivedFromTaskId
+      while (cursor) {
+        if (visited.has(cursor)) {
+          return c.json({ error: 'Derivation would create a cycle' }, 400)
+        }
+        visited.add(cursor)
+        const ancestor: { derivedFromTaskId: string | null } | undefined = db
+          .select({ derivedFromTaskId: tasks.derivedFromTaskId })
+          .from(tasks)
+          .where(eq(tasks.id, cursor))
+          .get()
+        cursor = ancestor?.derivedFromTaskId ?? null
+      }
     }
 
     // All DB writes in a single transaction: task insert + tags + dependencies + derivation
@@ -966,6 +984,15 @@ app.delete('/:id', (c) => {
   db.delete(taskRelationships).where(
     or(eq(taskRelationships.taskId, id), eq(taskRelationships.relatedTaskId, id))
   ).run()
+
+  // Cascade-unset derivedFromTaskId on any task that pointed at this one as parent.
+  // Reviewer note (#58): the schema field has no FK + no onDelete, so without this
+  // children would silently keep a dangling parent id and DerivedFromBadge would
+  // resolve to undefined. Equivalent to onDelete: 'set null'.
+  db.update(tasks)
+    .set({ derivedFromTaskId: null, updatedAt: now })
+    .where(eq(tasks.derivedFromTaskId, id))
+    .run()
 
   db.delete(tasks).where(eq(tasks.id, id)).run()
   broadcast({ type: 'task:updated', payload: { taskId: id } })


### PR DESCRIPTION
Closes #28

## 摘要

Task detail 页显示反向 derived list：当其他 task 的 `derivedFromTaskId` 指向当前 task 时列出来 + 显示 status badge。第一轮 reviewer 指出紫色边框 + 紫色背景 + 紫色 heading + 紫色文字链接四重叠加，视觉权重比相邻 Dependencies / Links / Pull Request card 还高，但这块是次要 reverse-lookup 信息。第二轮把紫色权重收回到只剩 `GitForkIcon` 作为唯一语义标记。

第一轮 review 的 sort 要求也修了（按 status order + createdAt 显式排序）。

## 变更预演（Layer 1）

不适用 — 用 `useTasks()` 现有 list filter。

## 落地核对（Layer 2）

```
$ bunx eslint frontend/components/task/derived-tasks-list.tsx
LINT=0
$ bunx tsc --noEmit
TSC=0
```

## 启动 / 运行时顺序（Layer 3）

不适用。

## 端到端业务行为（Layer 4）

`agent-browser` 打开 Parent task 详情页（已有 1 个 child）：

![PR58 v2 — toned-down derived list (普通 card 风格 + 紫色 GitFork 图标)](https://raw.githubusercontent.com/Mouriya-Emma/fulcrum/0065a089d7c62c8a3402193b2f511da96d9ff16f/screenshots/e2e-evidence/pr-58-v2-toned-down.png)

可见普通 `border bg-card` 容器、`text-muted-foreground` heading "Derived tasks (1)"、普通文字色链接 "Derived child v2"、灰色 "To Do" status badge——跟 Dependencies / Links 等其他 panel section 视觉同等。紫色仅保留在 heading 旁的 GitForkIcon 作为"派生关系"语义标记。


### v3 server-side fix（cascade-unset + cycle defense）

`reviewer 第三轮指出 schema 没 FK + 没 onDelete + 没循环防御。delete handler 加 cascade-unset，POST 加 ancestry-walk cycle check。

cURL e2e（[完整 transcript](https://raw.githubusercontent.com/Mouriya-Emma/fulcrum/main/screenshots/e2e-evidence/pr-58-v3-cascade-cycle.txt)）：

```
# Step 1: create A → B(parent=A) → C(parent=B)
# Step 2: SQL 注入 cycle (A.derivedFromTaskId=C 形成 A→C→B→A 闭环)
# POST D derivedFromTaskId=A → ancestry walk 命中已 visited
HTTP 400
{"error":"Derivation would create a cycle"}

# Step 3: cascade-unset
B.derivedFromTaskId = 066df4a0-... (before)
DELETE /api/tasks/A → HTTP 200
B.derivedFromTaskId = None  (after)
```

## Analysis

第一轮 reviewer 担心两条 render 路径（ManualTaskView 和 TaskDetailsPanel）双挂载——已在 component 顶部加 comment 说明 task type 互斥（manual/draft → ManualTaskView；worktree/scratch → TaskDetailsPanel；没有 task state 同时撞两边）。STATUS_ORDER 排序让 IN_PROGRESS / IN_REVIEW 浮顶，DONE / CANCELED 沉底，user 一眼看到还在阻塞父任务的 active 子任务。

via [HAPI](https://hapi.run)