### PR TITLE
显示空的派生任务列表

### DIFF
--- a/frontend/components/task/derived-tasks-list.tsx
+++ b/frontend/components/task/derived-tasks-list.tsx
@@ -47,30 +47,32 @@ export function DerivedTasksList({ taskId }: DerivedTasksListProps) {
     .slice()
     .sort(compareDerived)
 
-  if (children.length === 0) return null
-
   return (
     <div className="rounded-lg border bg-card p-4">
       <h3 className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground mb-2">
         <HugeiconsIcon icon={GitForkIcon} size={14} className="text-purple-600 dark:text-purple-400" />
         {t('derivedTasks.heading', { count: children.length })}
       </h3>
-      <ul className="flex flex-col gap-1.5">
-        {children.map((child) => (
-          <li key={child.id} className="flex items-center gap-2 text-sm">
-            <Link
-              to="/tasks/$taskId"
-              params={{ taskId: child.id }}
-              className="truncate hover:underline flex-1"
-            >
-              {child.title}
-            </Link>
-            <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${STATUS_CLASS[child.status] ?? STATUS_CLASS.TO_DO}`}>
-              {tc(`statuses.${child.status}`)}
-            </span>
-          </li>
-        ))}
-      </ul>
+      {children.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('derivedTasks.empty')}</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {children.map((child) => (
+            <li key={child.id} className="flex items-center gap-2 text-sm">
+              <Link
+                to="/tasks/$taskId"
+                params={{ taskId: child.id }}
+                className="truncate hover:underline flex-1"
+              >
+                {child.title}
+              </Link>
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${STATUS_CLASS[child.status] ?? STATUS_CLASS.TO_DO}`}>
+                {tc(`statuses.${child.status}`)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/frontend/i18n/locales/en/tasks.json
+++ b/frontend/i18n/locales/en/tasks.json
@@ -144,7 +144,8 @@
     "derivedLabel": "derived"
   },
   "derivedTasks": {
-    "heading": "Derived tasks ({{count}})"
+    "heading": "Derived tasks ({{count}})",
+    "empty": "No derived tasks"
   },
   "initializeModal": {
     "title": "Initialize as Worktree Task",

--- a/frontend/i18n/locales/zh/tasks.json
+++ b/frontend/i18n/locales/zh/tasks.json
@@ -144,7 +144,8 @@
     "derivedLabel": "派生"
   },
   "derivedTasks": {
-    "heading": "派生任务（{{count}}）"
+    "heading": "派生任务（{{count}}）",
+    "empty": "暂无派生任务"
   },
   "initializeModal": {
     "title": "初始化为工作树任务",


### PR DESCRIPTION
Closes #43

## 摘要

父任务详情页现在即使没有派生子任务，也会显示 `Derived tasks (0)` / `派生任务（0）` 区块和本地化空状态文案，避免用户误以为反向查找区域缺失。

## 变更预演（Layer 1）

- `git diff --check`：通过，无空白错误。
- 变更限定在 `frontend/components/task/derived-tasks-list.tsx` 与 `frontend/i18n/locales/{en,zh}/tasks.json`。
- 分析：本次只移除零子任务时的 early return，并在原有 card 内增加 empty-state 分支；正向列表渲染和 child link/status 展示路径保持不变。

## 落地核对（Layer 2）

- `mise run build`：通过，完成 `bun install`、TypeScript build 与 Vite production build。
- `mise run test:file server/routes/derived-tasks.test.ts`：通过，`13 pass, 0 fail`。
- 分析：build 覆盖前端类型与打包路径，focused test 覆盖 derived task API/关联逻辑；本次 UI 改动复用现有 `children` 数据来源，没有改后端 schema 或 API。

## 启动 / 运行时顺序（Layer 3）

- 启动隔离后端：`HOME=.coder-loop/evidence/issue-43/dev-home FULCRUM_DIR=.coder-loop/evidence/issue-43/dev-fulcrum PORT=8888 bun server/index.ts`，服务响应成功。
- 启动前端：`VITE_BACKEND_PORT=8888 FRONTEND_PORT=5173 DEBUG=1 bunx vite --port 5173`，页面可访问。
- 分析：运行时验证使用隔离 HOME/FULCRUM_DIR，避免污染真实 Fulcrum 配置；前后端端口显式绑定，证明页面从本地 API 数据渲染派生任务区域。

## 端到端业务行为（Layer 4）

- `.coder-loop/evidence/issue-43/derived-tasks-positive.png`：父任务详情正例，显示 `派生任务（1）`、派生子任务标题与状态。
- `.coder-loop/evidence/issue-43/derived-tasks-child-navigation.png`：从派生子任务链接进入 child detail，证明列表链接目标可导航且 child 仍展示 `Derived from` 父任务信息。
- `.coder-loop/evidence/issue-43/derived-tasks-empty-state.png`：无派生子任务父任务详情负例，显示 `派生任务（0）` 与 `暂无派生任务`。
- 分析：agent-browser 覆盖了有子任务、点击子任务、无子任务三个业务路径，截图保存在 issue evidence 目录下。

## Analysis

证据覆盖了代码范围、构建、focused test、隔离运行时和本地浏览器 E2E。主要剩余风险是视觉文案是否需要产品再调整，但功能行为和回归路径已被截图与验证命令覆盖。