### PR TITLE
fix(issue-23): 显示远程终端 host 标识

### DIFF
--- a/frontend/components/terminal/terminal-grid.tsx
+++ b/frontend/components/terminal/terminal-grid.tsx
@@ -10,10 +10,11 @@ import { Terminal } from './terminal'
 import { TerminalStatusBar } from './terminal-status'
 import { Button } from '@/components/ui/button'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Cancel01Icon, PlusSignIcon, Loading03Icon, Maximize02Icon, ArrowShrink02Icon } from '@hugeicons/core-free-icons'
+import { Cancel01Icon, PlusSignIcon, Loading03Icon, Maximize02Icon, ArrowShrink02Icon, ComputerIcon } from '@hugeicons/core-free-icons'
 import { TaskTerminalHeader } from './task-terminal-header'
 import { RepoTerminalHeader } from './repo-terminal-header'
 import type { TerminalInfo } from '@/hooks/use-terminal-ws'
+import type { Host } from '@/types'
 import type { Terminal as XTerm } from '@xterm/xterm'
 import { useIsMobile } from '@/hooks/use-is-mobile'
 import { MobileTerminalControls } from './mobile-terminal-controls'
@@ -57,6 +58,8 @@ interface TerminalGridProps {
   taskInfoByCwd?: Map<string, TaskInfo>
   /** Map terminal cwd to repo info for navigation and display */
   repoInfoByCwd?: Map<string, RepoInfo>
+  /** Map host id to host info for remote terminal badges */
+  hostById?: Map<string, Host>
   /** Custom message to show when there are no terminals */
   emptyMessage?: string
 }
@@ -65,6 +68,7 @@ interface TerminalPaneProps {
   terminal: TerminalInfo
   taskInfo?: TaskInfo
   repoInfo?: RepoInfo
+  host?: Host
   isMobile?: boolean
   onClose?: () => void
   onReady?: (xterm: XTerm) => void
@@ -79,7 +83,21 @@ interface TerminalPaneProps {
   canMaximize?: boolean
 }
 
-const TerminalPane = observer(function TerminalPane({ terminal, taskInfo, repoInfo, isMobile, onClose, onReady, onResize, onRename, onContainerReady, setupImagePaste, onFocus, sendInputToTerminal, isMaximized, onMaximize, onMinimize, canMaximize }: TerminalPaneProps & { sendInputToTerminal?: (terminalId: string, text: string) => void }) {
+const formatHostTooltip = (host: Host) => `${host.name} (${host.username}@${host.hostname}:${host.port})`
+
+function TerminalHostBadge({ host }: { host: Host }) {
+  return (
+    <span
+      className="inline-flex max-w-36 shrink-0 items-center gap-1 truncate rounded-sm bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 ring-1 ring-blue-200 dark:bg-blue-950/40 dark:text-blue-400 dark:ring-blue-900"
+      title={formatHostTooltip(host)}
+    >
+      <HugeiconsIcon icon={ComputerIcon} size={12} strokeWidth={2} />
+      <span className="truncate">{host.name}</span>
+    </span>
+  )
+}
+
+const TerminalPane = observer(function TerminalPane({ terminal, taskInfo, repoInfo, host, isMobile, onClose, onReady, onResize, onRename, onContainerReady, setupImagePaste, onFocus, sendInputToTerminal, isMaximized, onMaximize, onMinimize, canMaximize }: TerminalPaneProps & { sendInputToTerminal?: (terminalId: string, text: string) => void }) {
   const store = useStore()
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
@@ -140,6 +158,7 @@ const TerminalPane = observer(function TerminalPane({ terminal, taskInfo, repoIn
           onRename={onRename}
         />
         <div className="flex items-center gap-1 mr-1">
+          {host && <TerminalHostBadge host={host} />}
           {canMaximize && (
             <Button
               variant="ghost"
@@ -271,6 +290,7 @@ export function TerminalGrid({
   sendInputToTerminal,
   taskInfoByCwd,
   repoInfoByCwd,
+  hostById,
   emptyMessage,
 }: TerminalGridProps) {
   const isMobile = useIsMobile()
@@ -325,6 +345,7 @@ export function TerminalGrid({
   const renderTerminalPane = (terminal: TerminalInfo) => {
     const taskInfo = terminal.cwd ? taskInfoByCwd?.get(terminal.cwd) : undefined
     const repoInfo = terminal.cwd ? repoInfoByCwd?.get(terminal.cwd) : undefined
+    const host = terminal.hostId ? hostById?.get(terminal.hostId) : undefined
     // Regular and repo terminals can be maximized when there are multiple terminals (not task terminals)
     const canMaximize = !taskInfo && terminals.length > 1
     return (
@@ -332,6 +353,7 @@ export function TerminalGrid({
         terminal={terminal}
         taskInfo={taskInfo}
         repoInfo={repoInfo}
+        host={host}
         isMobile={isMobile}
         onClose={onTerminalClose ? () => onTerminalClose(terminal.id) : undefined}
         onReady={onTerminalReady ? (xterm) => onTerminalReady(terminal.id, xterm) : undefined}

--- a/frontend/hooks/use-terminal-ws.ts
+++ b/frontend/hooks/use-terminal-ws.ts
@@ -32,6 +32,7 @@ export interface TerminalInfo {
   createdAt: number
   tabId?: string
   positionInTab?: number
+  hostId?: string
 }
 
 interface UseTerminalWSOptions {
@@ -132,6 +133,7 @@ function toTerminalInfo(terminal: ITerminal): TerminalInfo {
     createdAt: terminal.createdAt,
     tabId: terminal.tabId ?? undefined,
     positionInTab: terminal.positionInTab,
+    hostId: terminal.hostId,
   }
 }
 

--- a/frontend/routes/terminals/index.tsx
+++ b/frontend/routes/terminals/index.tsx
@@ -19,6 +19,7 @@ import type { ITerminal, ITab } from '@/stores'
 import { useTasks } from '@/hooks/use-tasks'
 import { useRepositories } from '@/hooks/use-repositories'
 import { useProjects } from '@/hooks/use-projects'
+import { useHosts } from '@/hooks/use-hosts'
 import { useTerminalViewState } from '@/hooks/use-terminal-view-state'
 import { useHotkeys } from '@/hooks/use-hotkeys'
 import { cn } from '@/lib/utils'
@@ -43,6 +44,7 @@ function toTerminalInfo(terminal: ITerminal): TerminalInfo {
     createdAt: terminal.createdAt,
     tabId: terminal.tabId ?? undefined,
     positionInTab: terminal.positionInTab,
+    hostId: terminal.hostId,
   }
 }
 
@@ -213,8 +215,15 @@ const TerminalsView = observer(function TerminalsView() {
   const { data: tasks = [], status: tasksStatus } = useTasks()
   const { data: repositories = [] } = useRepositories()
   const { data: projects = [] } = useProjects()
+  const { data: hosts = [] } = useHosts()
 
-  // Map repository path to repository id for linking
+  const hostById = useMemo(() => {
+    const map = new Map<string, (typeof hosts)[number]>()
+    for (const host of hosts) {
+      map.set(host.id, host)
+    }
+    return map
+  }, [hosts])
   const repoIdByPath = useMemo(() => {
     const map = new Map<string, string>()
     for (const repo of repositories) {
@@ -998,6 +1007,7 @@ const TerminalsView = observer(function TerminalsView() {
           sendInputToTerminal={sendInputToTerminal}
           taskInfoByCwd={activeTabId === ALL_TASKS_TAB_ID ? taskInfoByCwd : undefined}
           repoInfoByCwd={activeTabId === ALL_REPOS_TAB_ID ? repoInfoByCwd : undefined}
+          hostById={hostById}
           emptyMessage={activeTabId === ALL_REPOS_TAB_ID ? t('emptyRepos') : activeTabId === ALL_TASKS_TAB_ID ? t('emptyTasks') : undefined}
         />
       </div>

--- a/frontend/stores/models/terminal.ts
+++ b/frontend/stores/models/terminal.ts
@@ -26,6 +26,7 @@ export const TerminalModel = types
     createdAt: types.number,
     tabId: types.maybeNull(types.string),
     positionInTab: types.optional(types.number, 0),
+    hostId: types.maybe(types.string),
   })
   .volatile(() => ({
     /** The xterm.js terminal instance */
@@ -72,6 +73,7 @@ export const TerminalModel = types
       if (data.rows !== undefined) self.rows = data.rows
       if (data.tabId !== undefined) self.tabId = data.tabId
       if (data.positionInTab !== undefined) self.positionInTab = data.positionInTab
+      if (data.hostId !== undefined) self.hostId = data.hostId
     },
 
     /** Set the xterm.js terminal instance */


### PR DESCRIPTION
Closes #23

## 摘要

持久终端页现在会保留服务端下发的 `hostId`，并在远程终端 header 右侧显示蓝色电脑图标 host badge。badge tooltip 会展示完整连接信息：host 名称、username、hostname 和 port。

## 变更预演（Layer 1）

本轮是前端显示层改动，没有数据库迁移或配置变更。

```text
git diff -- frontend/stores/models/terminal.ts frontend/hooks/use-terminal-ws.ts frontend/routes/terminals/index.tsx frontend/components/terminal/terminal-grid.tsx
4 files changed, 39 insertions(+), 3 deletions(-)
```

分析：后端 `TerminalInfo.hostId` 与 `terminals.hostId` 已存在，本 PR 只补齐前端 MST model、legacy TerminalInfo adapter、Terminals route 的 host lookup，以及 TerminalGrid 的 badge 渲染。

## 落地核对（Layer 2）

变更文件：

- `frontend/stores/models/terminal.ts`：MST `TerminalModel` 增加 `hostId` 并在 server update 中同步。
- `frontend/hooks/use-terminal-ws.ts`：legacy `TerminalInfo` 类型和转换保留 `hostId`。
- `frontend/routes/terminals/index.tsx`：通过 `useHosts()` 建立 `hostById`，传入 `TerminalGrid`。
- `frontend/components/terminal/terminal-grid.tsx`：对有 host 的终端显示蓝色 `ComputerIcon` badge，并用 `title` 暴露 `name (username@hostname:port)`。

`mise run build` 通过：

```text
vite v7.3.0 building client environment for production...
✓ 5681 modules transformed.
✓ built in 7.99s
Finished in 17.90s
```

`mise run test` 通过（全量测试；本改动无现有对应 focused test 文件）：

```text
Running linter...
✖ 2 problems (0 errors, 2 warnings)
Running tests...
bun test v1.3.13 (bf2e2cec)
 1334 pass
 9 skip
 0 fail
Ran 1343 tests across 69 files. [38.23s]
```

分析：两条 lint warning 位于 `frontend/components/viewer/*`，与本 PR 修改文件无关。

## 启动 / 运行时顺序（Layer 3）

本轮使用隔离 `FULCRUM_DIR` 启动 server/client 进行浏览器 smoke，没有触碰真实 Fulcrum 数据目录。

```text
FULCRUM_DIR=.coder-loop/evidence/issue-23/fulcrum-data PORT=7783 bun --watch server/index.ts
DEBUG=1 VITE_BACKEND_PORT=7783 bunx vite --port 5183 --host 0.0.0.0
```

server/client ready 摘要：

```text
{"src":"Server","msg":"Fulcrum server running","ctx":{"port":7783,"healthCheck":"http://localhost:7783/health","api":"http://localhost:7783/api/tasks","webSocket":"ws://localhost:7783/ws/terminal"}}
VITE v7.3.0  ready in 701 ms
Network: http://192.168.1.220:5183/
```

分析：当前 CI/browser 环境缺少 `dtach`，所以无法在该环境真实创建本地持久终端；远程终端 badge 的正向路径由已存在后端 `hostId` 下发链路 + 本 PR 的前端类型/渲染链路 + build/typecheck 覆盖。

## 端到端业务行为（Layer 4）

local agent-browser 打开隔离 dev server 的 Terminals 页面并截图，补齐远程终端 badge 正向态与空/disabled no-regression：

正向态：隔离 SQLite 种子包含 `hosts.id=issue23-host` 和 `terminals.host_id=issue23-host`，浏览器截图显示 `Remote shell` header 中的蓝色电脑图标 host badge `staging-vm`。

![Remote terminal host badge](https://raw.githubusercontent.com/Mouriya-Emma/fulcrum/0065a089d7c62c8a3402193b2f511da96d9ff16f/screenshots/e2e-evidence/issue-23/run-2026-05-03-22-42-58-issue-23/terminal-remote-host-badge.png)

负向 / disabled no-regression：无终端数据时 Terminals 页面正常加载，未崩溃。

![Terminals empty smoke](https://raw.githubusercontent.com/Mouriya-Emma/fulcrum/0065a089d7c62c8a3402193b2f511da96d9ff16f/screenshots/e2e-evidence/issue-23/run-2026-05-03-22-31-44-issue-23/terminals-empty.png)

本地来源路径：

```text
.coder-loop/evidence/issue-23/terminal-remote-host-badge.png
.coder-loop/evidence/issue-23/terminals-empty.png
.coder-loop/evidence/issue-23/terminals-empty.snapshot.txt
.coder-loop/evidence/issue-23/server.log
.coder-loop/evidence/issue-23/client.log
.coder-loop/evidence/issue-23/positive-server-7785.log
.coder-loop/evidence/issue-23/positive-client-5185.log
```

分析：截图覆盖 Terminals 页 no-regression 与空态，也覆盖 `hostId -> hostById -> TerminalHostBadge` 的真实前端渲染正向态。正向截图使用隔离 `FULCRUM_DIR` 和临时种子数据，不触碰真实 Fulcrum 数据目录或真实 SSH 凭据。

## Analysis

证据现在同时覆盖 Terminals 页加载、空态 no-regression，以及远程终端 header 中 `staging-vm` host badge 的正向视觉结果。实现链路从后端已存在的 `hostId` 一直贯穿到前端 `hostById` 查找和 `TerminalHostBadge` 渲染；剩余风险仅是截图使用隔离种子数据而非真实 SSH 会话。