### PR TITLE
fix(issue-151): mise.toml `bun test` 补 `--max-concurrency=1` 与 upstream e9fb02ee 对齐

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -226,10 +226,10 @@ echo "[test] Isolated environment: HOME=$HOME FULCRUM_DIR=$FULCRUM_DIR" >&2
 # Run tests serially to avoid env var conflicts between test files
 echo "Running tests..." >&2
 if [ "$usage_verbose" = "true" ]; then
-  bun test
+  bun test --max-concurrency=1
 else
   # Filter to show only failures and summary (exclude diff lines starting with +/-)
-  bun test 2>&1 | grep -v '^[+-]' | grep -E '(^bun test|[(]fail[)]|✗|expect[(]received[)]|^ *[0-9]+ (pass|fail|skip)|^Ran [0-9]+ tests)' || [ ${PIPESTATUS[0]} -eq 0 ]
+  bun test --max-concurrency=1 2>&1 | grep -v '^[+-]' | grep -E '(^bun test|[(]fail[)]|✗|expect[(]received[)]|^ *[0-9]+ (pass|fail|skip)|^Ran [0-9]+ tests)' || [ ${PIPESTATUS[0]} -eq 0 ]
 fi
 """
 


### PR DESCRIPTION
## Summary

把 `mise.toml` 的 `bun test` 命令补上 `--max-concurrency=1` flag，与 upstream `knowsuchagency/fulcrum@e9fb02ee` 行为对齐：

- verbose 分支：`bun test` → `bun test --max-concurrency=1`
- 默认分支：`bun test 2>&1 | grep ...` → `bun test --max-concurrency=1 2>&1 | grep ...`

注释 `# Run tests serially to avoid env var conflicts between test files` 已经在 fork 中存在但 flag 没生效，意图与实现不一致。

Closes #151

## Background

`Mouriya-Emma/fulcrum#150`（第二轮 upstream diff audit）把 `e9fb02ee` 整体判为 `already-present`，但漏审了它顺手带的 `mise.toml` 改动。手动 `git diff origin/main upstream-direct/main -- mise.toml` 显示 `--max-concurrency=1` 在 fork 缺失。

## Test plan

### Layer 1: 单元 / 集成

- [x] **AC #1 — `mise run test` 默认 quiet 模式跑全套测试**：本地运行结果

  ```
  [test] Isolated environment: HOME=/var/folders/.../fulcrum-test-home-XXXXXX.UcP5Gdw8Fg FULCRUM_DIR=/var/folders/.../fulcrum-test-dir-XXXXXX.TDXxArOZtI
  Running tests...
  bun test v1.3.13 (bf2e2cec)
   1481 pass
   9 skip
   0 fail
  Ran 1490 tests across 80 files. [49.98s]
  exit=0
  ```

- [x] **AC #3 — `mise.toml` 中两处 `bun test` 调用都含 `--max-concurrency=1`**：

  ```
  $ grep -c "bun test --max-concurrency=1" mise.toml
  2
  ```

- [x] **AC #4 — 与 upstream byte-equal**：

  ```
  $ git diff HEAD upstream-direct/main -- mise.toml
  (empty)
  ```

### Layer 2: 改动 diff

PR HEAD `0bcae1c87c221dafe1dc65b53b8bb242c9f099d6`：

```diff
@@ -226,10 +226,10 @@ echo "[test] Isolated environment: HOME=$HOME FULCRUM_DIR=$FULCRUM_DIR" >&2
 # Run tests serially to avoid env var conflicts between test files
 echo "Running tests..." >&2
 if [ "$usage_verbose" = "true" ]; then
-  bun test
+  bun test --max-concurrency=1
 else
   # Filter to show only failures and summary (exclude diff lines starting with +/-)
-  bun test 2>&1 | grep -v '^[+-]' | grep -E '(^bun test|[(]fail[)]|✗|expect[(]received[)]|^ *[0-9]+ (pass|fail|skip)|^Ran [0-9]+ tests)' || [ ${PIPESTATUS[0]} -eq 0 ]
+  bun test --max-concurrency=1 2>&1 | grep -v '^[+-]' | grep -E '(^bun test|[(]fail[)]|✗|expect[(]received[)]|^ *[0-9]+ (pass|fail|skip)|^Ran [0-9]+ tests)' || [ ${PIPESTATUS[0]} -eq 0 ]
 fi
 """
```

### Layer 3 / 4

仅 `mise.toml` 内 `bun test` 调用串行化；没有 UI 改动、没有新模块。Layer 3 (UI) / Layer 4 (E2E) 不适用。

## Analysis

- `--max-concurrency=1` 是 `bun test` 自身的串行化 flag，让多个 `*.test.ts` 文件按顺序而不是并行跑；不改测试逻辑、不改 isolation 路径 (`HOME` / `FULCRUM_DIR` 仍是 `mktemp -d` 临时目录)。
- 测试套数与时长有可观察影响（串行后 50s vs 之前并行可能 30-40s），但避免了 env var race，与 fork 已有的"环境变量串行 isolation"意图一致。
- AC #2 (`mise run test -- -v`) 已通过 AC #1 + diff 间接验证（同一段 `if` 分支结构，两侧都加了同一个 flag）。
