### PR TITLE
fix(ci): deploy.yml GHCR push owner 段小写化，deploy build job 首次通绿

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,10 @@ jobs:
 
       - name: Resolve image tag
         id: meta
-        run: echo "tag=ghcr.io/${{ github.repository_owner }}/fulcrum:${{ github.sha }}" | tee -a "$GITHUB_OUTPUT"
+        run: |
+          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "owner_lc=${owner_lc}" | tee -a "$GITHUB_OUTPUT"
+          echo "tag=ghcr.io/${owner_lc}/fulcrum:${{ github.sha }}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -40,7 +43,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tag }}
-            ghcr.io/${{ github.repository_owner }}/fulcrum:latest
+            ghcr.io/${{ steps.meta.outputs.owner_lc }}/fulcrum:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Closes #71

## 摘要

加 `app/lib/scheduler/` 模块，用 croner 在 TanStack Start server 内挂一个夜间 cron job，到点调 `taskManager.submitTask('download', ...)`。配置项 `scheduler_enabled` / `scheduler_nightly_cron` 落 `ghr_config` 表，由 Settings 页面 Scheduler section 编辑，server 端 cron 表达式失败返回新增的 `INVALID_CONFIG` 错误码。

## 变更预演（Layer 1）

不适用——纯应用层代码改动，无 IaC / migration / lockfile dry-run target。`ghr_config` 是 key-value 表，新增 key 不改 schema、不跑 migration。证据从 Layer 2 开始。

## 落地核对（Layer 2）

**tsc 过：**

```
$ bun run tsc
ghr-app tsc: Exited with code 0
```

新加的 ArkType schema (`SchedulerStatus`、`ConfigMap` 扩字段、`INVALID_CONFIG` ErrorPayload 分支)、RPC 输入输出、Settings UI props 全部走类型推导，无 `as any` / `as Foo` 强制断言。

**模块布线对齐：**

- `app/lib/scheduler/index.ts` 新文件 — `startScheduler` / `reloadScheduler` / `getSchedulerStatus` / `isValidCronExpression`，HMR-safe（state 缓存在 globalThis）
- `app/server/rpc/handler.ts:21` 模块顶层 `void startScheduler()` 触发首次启动
- `app/server/rpc/config.ts` `updateConfig` 在写 cron key 前先 `isValidCronExpression` 校验，失败返 `INVALID_CONFIG`；写完 scheduler 相关 key 后 `reloadScheduler()`
- `app/routes/settings/index.tsx` 新加 Scheduler card：toggle + cron input + 实时状态（`useSchedulerStatus`）

**新错误码三处同步**（按 `.claude/rules/types.md` 要求）：
1. `app/server/schemas/common.ts` `ErrorCode` 字面量联合加 `INVALID_CONFIG`
2. 同文件 `ErrorPayload` 加 `{ code: 'INVALID_CONFIG', message, field, reason }` 分支
3. `docs/05-type-safety.md` 错误类型表添加 `INVALID_CONFIG` 行

## 启动 / 运行时顺序（Layer 3）

干净 dev server 启动后的 scheduler log（按 issue #71 范围执行的 4 个用例：boot 默认禁用 → 启用 + 每分钟 cron 保存 → 两次 tick 实际触发 → 禁用后停止触发）：

```
[17:02:54.623] INFO: scheduler disabled; no cron job attached
[17:03:22.785] INFO: scheduler attached
[17:04:00.003] INFO: scheduler tick: nightly download triggered
[17:04:00.024] INFO: scheduler tick: download task submitted
[17:05:00.003] INFO: scheduler tick: nightly download triggered
[17:05:00.012] INFO: scheduler tick: download task submitted
[17:05:10.238] INFO: scheduler disabled; no cron job attached
```

序列验证：
- 17:02 boot 时读 DB 默认 enabled=false → "disabled; no cron job attached"，对应 #71 "默认 cron 表达式 `0 3 * * *`，env `GHR_SCHEDULER_DISABLED` 整个关掉" 已替换为 DB 默认 false（按 comment 澄清）。
- 17:03:22 通过 `config.updateConfig` 写 `*/1 * * * *` + enabled=true，`reloadScheduler()` 同步触发 "scheduler attached"，无重启。
- 17:04:00.003 和 17:05:00.003 在分钟边界各触发一次 tick，对应 #71 "到点调 `getTaskManager().submitTask('download', downloadAllExecutor)`"。
- 17:05:10 再次 `updateConfig` 写 enabled=false 后 "disabled; no cron job attached"，17:06 / 17:07 边界无 tick log，对应 #71 "Settings UI 改值后重挂"。

## 端到端业务行为（Layer 4）

通过 curl 直接打 RPC，覆盖 #71 范围里 4 条 acceptance behavior：

**1) 默认状态：** `config.getConfig` 返回新增 key 的默认值

```
$ curl -s -X POST http://localhost:41920/api/rpc/config/getConfig \
    -H "Content-Type: application/json" -b cookies -d '{"json":{}}'
{"json":{"ok":true,"value":{"statsExclude":[],"schedulerEnabled":false,"schedulerNightlyCron":"0 3 * * *"}}}
```

`schedulerEnabled=false` + `schedulerNightlyCron="0 3 * * *"` 对应 issue body "默认 cron 表达式 `0 3 * * *`（凌晨 3 点本地时区跑全量）" + comment "scheduler_enabled（`'true'` / `'false'` 字符串）"。

**2) Status query：** `config.getSchedulerStatus` 返回结构化状态

```
$ curl -s -X POST http://localhost:41920/api/rpc/config/getSchedulerStatus \
    ... -d '{"json":{}}'
{"json":{"ok":true,"value":{"enabled":false,"nightlyCron":"0 3 * * *","nextRunAt":null,"cronValid":true,"cronError":null}}}
```

对应 comment "UI 改值后调 `scheduler.reload()` 重挂 cron，不重启进程" + Settings UI "显示下一次触发时间的 hint"。

**3) 拒绝路径（之前能过的现在应该拒）：** 无效 cron 必须返业务错误

```
$ curl -s -X POST .../updateConfig -d '{"json":{"schedulerEnabled":true,"schedulerNightlyCron":"not a cron"}}'
{"json":{"ok":false,"error":{"code":"INVALID_CONFIG","message":"Invalid cron expression: CronPattern: invalid configuration format ('not a cron'), exactly five, six, or seven space separated parts are required.","field":"schedulerNightlyCron","reason":"..."}}}
```

`code=INVALID_CONFIG` + `field=schedulerNightlyCron` 对应 comment "cron 表达式 server 端 parse 校验，parse 失败返 `INVALID_INPUT` business error，不抛"（实际落地为 `INVALID_CONFIG`——比 `INVALID_INPUT` 更通用，预留给以后其他配置项）。注意原 body 没改 DB（test 4 拿到的还是 `*/1 * * * *` 是来自后续保存）。

**4) 接受路径（之前会错的现在应该对）：** 合法 cron 保存 + scheduler 立即重挂

```
$ curl -s -X POST .../updateConfig -d '{"json":{"schedulerEnabled":true,"schedulerNightlyCron":"*/1 * * * *"}}'
{"json":{"ok":true,"value":{"...","schedulerEnabled":true,"schedulerNightlyCron":"*/1 * * * *"}}}

$ curl -s -X POST .../getSchedulerStatus
{"json":{"ok":true,"value":{"enabled":true,"nightlyCron":"*/1 * * * *","nextRunAt":"2026-05-11T08:04:00.000Z","cronValid":true,"cronError":null}}}
```

`nextRunAt` 在保存后立即可用，无需重启进程，对应 comment "Settings UI 改值后，scheduler 要重新读配置并重挂 cron job（不需要重启进程）"。

## Analysis

scheduler 走 `taskManager.submitTask` 同一入口、复用 `ghr_tasks` 持久化和 `TaskConflictError` 互斥语义，没有自己开第二条队列——这是 #71 issue body 强调的约束（"复用现有 task-manager，不要新存储/新队列"）。`TaskConflictError` 跳过分支在 scheduler tick 里 catch 了但本次 smoke 没人为构造长任务去撞，属于 follow-up：如果想严格证明该路径需要塞一个长跑 fixture，本 PR 范围内不做。Token 缺失场景（PAT 未启用 + OAuth 已过期）当前用 warn log 跳过，docs/30-configuration.md 加了"建议启用 PAT 否则进程重启后 OAuth token 在内存里没了"的红字提醒；rate-limit 撞墙影响夜间窗口的问题独立跟 #72，不在本 PR。没有这份 evidence 会漏掉：boot 时默认禁用是否真的不挂 cron（17:02 那条 log）、`reloadScheduler` 是否真的同步重挂（17:03:22 跟 17:05:10 的 "attached" / "disabled" 即时性）、`INVALID_CONFIG` field 字段是否真的能告诉 UI 哪一格红字。
