### PR TITLE
fix(apps/logs): fall back to latest deployment buildLogs when swarm empty

### DIFF
--- a/server/routes/apps.test.ts
+++ b/server/routes/apps.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test'
 import { createTestGitRepo, type TestGitRepo } from '../__tests__/fixtures/git'
 import { createTestApp } from '../__tests__/fixtures/app'
 import { setupTestEnv, type TestEnv } from '../__tests__/utils/env'
-import { db, apps, appServices, repositories } from '../db'
+import { db, apps, appServices, deployments, repositories } from '../db'
 import { eq } from 'drizzle-orm'
 import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -13,6 +13,18 @@ mock.module('../services/docker-compose', () => ({
   checkDockerInstalled: () => Promise.resolve(true),
   checkDockerRunning: () => Promise.resolve(true),
   composeBuild: () => Promise.resolve({ success: true, output: '' }),
+}))
+
+// Mutable docker-swarm mock state so individual tests can simulate the
+// "docker present + non-empty logs" and "docker absent" paths.
+type SwarmService = { name: string; serviceName: string }
+let mockStackServices: () => Promise<SwarmService[]> = () => Promise.resolve([])
+let mockServiceLogs: (name: string, tail?: number) => Promise<string> =
+  () => Promise.resolve('')
+mock.module('../services/docker-swarm', () => ({
+  stackServices: (name: string) => mockStackServices(),
+  serviceLogs: (name: string, tail?: number) => mockServiceLogs(name, tail),
+  stackRemove: () => Promise.resolve({ success: true }),
 }))
 
 describe('Apps Routes', () => {
@@ -506,6 +518,156 @@ services:
       const res = await post('/api/apps/nonexistent/sync-services')
 
       expect(res.status).toBe(404)
+    })
+  })
+
+  describe('GET /api/apps/:id/logs', () => {
+    const seedAppOnly = (appId: string) => {
+      const now = new Date().toISOString()
+      db.insert(apps).values({
+        id: appId,
+        name: 'Logs App',
+        repositoryId: repoId,
+        branch: 'main',
+        composeFile: 'compose.yml',
+        status: 'running',
+        autoDeployEnabled: false,
+        createdAt: now,
+        updatedAt: now,
+      }).run()
+    }
+
+    const seedDeployment = (appId: string, buildLogs: string) => {
+      const now = new Date().toISOString()
+      db.insert(deployments).values({
+        id: nanoid(),
+        appId,
+        status: 'running',
+        gitCommit: 'test-commit',
+        gitMessage: 'test',
+        deployedBy: 'manual',
+        buildLogs,
+        startedAt: now,
+        completedAt: now,
+        createdAt: now,
+      }).run()
+    }
+
+    beforeEach(() => {
+      // Reset swarm mocks to "docker absent" baseline between tests
+      mockStackServices = () => Promise.resolve([])
+      mockServiceLogs = () => Promise.resolve('')
+    })
+
+    test('returns deployment buildLogs when docker swarm yields nothing', async () => {
+      const appId = nanoid()
+      seedAppOnly(appId)
+      seedDeployment(appId, 'line-a\nline-b\nline-c')
+
+      const { get } = createTestApp()
+      const res = await get(`/api/apps/${appId}/logs`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.logs).toBe('line-a\nline-b\nline-c')
+    })
+
+    test('prefers docker swarm logs over deployment fallback when both exist', async () => {
+      const appId = nanoid()
+      seedAppOnly(appId)
+      seedDeployment(appId, 'fallback-line')
+      mockStackServices = () => Promise.resolve([
+        { name: 'app_web', serviceName: 'web' },
+      ])
+      mockServiceLogs = () => Promise.resolve('swarm-line-1\nswarm-line-2')
+
+      const { get } = createTestApp()
+      const res = await get(`/api/apps/${appId}/logs`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.logs).toBe('=== web ===\nswarm-line-1\nswarm-line-2')
+      expect(body.logs).not.toContain('fallback-line')
+    })
+
+    test('returns empty string when neither swarm nor deployments have logs', async () => {
+      const appId = nanoid()
+      seedAppOnly(appId)
+      // No deployment row inserted
+
+      const { get } = createTestApp()
+      const res = await get(`/api/apps/${appId}/logs`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.logs).toBe('')
+    })
+
+    test('honors ?tail=N on the deployment fallback', async () => {
+      const appId = nanoid()
+      seedAppOnly(appId)
+      seedDeployment(appId, ['l1', 'l2', 'l3', 'l4', 'l5'].join('\n'))
+
+      const { get } = createTestApp()
+      const res = await get(`/api/apps/${appId}/logs?tail=2`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.logs).toBe('l4\nl5')
+    })
+
+    test('?service=<name> falls back to deployment when swarm returns empty', async () => {
+      const appId = nanoid()
+      seedAppOnly(appId)
+      seedDeployment(appId, 'service-fallback-line')
+
+      const { get } = createTestApp()
+      const res = await get(`/api/apps/${appId}/logs?service=web`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.logs).toBe('service-fallback-line')
+    })
+
+    test('reads the latest deployment when multiple exist', async () => {
+      const appId = nanoid()
+      seedAppOnly(appId)
+      // Insert older + newer; newer should win
+      const t0 = new Date(Date.now() - 60_000).toISOString()
+      const t1 = new Date().toISOString()
+      db.insert(deployments).values([
+        {
+          id: nanoid(),
+          appId,
+          status: 'running',
+          gitCommit: 'old',
+          gitMessage: 'old',
+          deployedBy: 'manual',
+          buildLogs: 'OLD',
+          startedAt: t0,
+          completedAt: t0,
+          createdAt: t0,
+        },
+        {
+          id: nanoid(),
+          appId,
+          status: 'running',
+          gitCommit: 'new',
+          gitMessage: 'new',
+          deployedBy: 'manual',
+          buildLogs: 'NEW',
+          startedAt: t1,
+          completedAt: t1,
+          createdAt: t1,
+        },
+      ]).run()
+
+      const { get } = createTestApp()
+      const res = await get(`/api/apps/${appId}/logs`)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.logs).toBe('NEW')
     })
   })
 })

--- a/server/routes/apps.ts
+++ b/server/routes/apps.ts
@@ -849,12 +849,26 @@ app.get('/:id/logs', async (c) => {
 
   const projectName = getProjectName(id, repo?.displayName)
 
+  // Fallback when no docker swarm output is available (e.g. docker-less prod
+  // renderer-only Fulcrum deployments): serve the latest deployment's
+  // buildLogs from the DB. Keeps `apps logs` useful for audit / dashboard
+  // surfaces that don't have a real docker host attached.
+  const tailLines = (s: string): string =>
+    s.split('\n').slice(-tail).join('\n')
+  const deploymentFallback = async (): Promise<string> => {
+    const latest = await db.query.deployments.findFirst({
+      where: eq(deployments.appId, id),
+      orderBy: [desc(deployments.createdAt)],
+    })
+    return latest?.buildLogs ? tailLines(latest.buildLogs) : ''
+  }
+
   // Get logs for specific service or all services
   if (service) {
     // Swarm service names are: stackName_serviceName
     const fullServiceName = `${projectName}_${service}`
     const logs = await serviceLogs(fullServiceName, tail)
-    return c.json({ logs })
+    return c.json({ logs: logs || (await deploymentFallback()) })
   }
 
   // Get logs from all services in the stack
@@ -868,7 +882,10 @@ app.get('/:id/logs', async (c) => {
     }
   }
 
-  return c.json({ logs: allLogs.join('\n\n') })
+  if (allLogs.length > 0) {
+    return c.json({ logs: allLogs.join('\n\n') })
+  }
+  return c.json({ logs: await deploymentFallback() })
 })
 
 // GET /api/apps/:id/status - Get service status


### PR DESCRIPTION
Closes #239.

## Summary

- \`GET /api/apps/:id/logs\` now falls back to the latest \`deployments.buildLogs\` row when docker swarm yields nothing (docker-less Fulcrum deployments — the homelab prod shape, intentional).
- Docker-present paths unchanged; swarm wins when it returns anything.
- Honors \`?tail=N\` on the fallback. Same shape for \`?service=<name>\`.

## Why

[\`server/routes/apps.ts:832-872\`](https://github.com/Mouriya-Emma/fulcrum/blob/main/server/routes/apps.ts#L832-L872) shelled out to docker swarm unconditionally. Prod Fulcrum on \`vctcn-app1\` does **not** bind the host docker socket (renderer ≠ Docker host), so the endpoint always returned \`{ logs: \"\" }\` even when the \`deployments\` table held populated content. This was the structural root cause of [mattermost-plugin-fulcrum#41](https://github.com/Mouriya-Emma/mattermost-plugin-fulcrum/issues/41) AC#4 — the 14-day stall mistakenly attributed to \"fixture seed missing\". Today's fixture seed via [Mouriya-Emma/fulcrum-audit-fixture](https://github.com/Mouriya-Emma/fulcrum-audit-fixture) (per [PR #238 / \`.claude/rules/e2e-audit-fixture.md\`](https://github.com/Mouriya-Emma/fulcrum/pull/238)) confirmed \`deployments.buildLogs\` is populated with realistic compose-up content; this PR makes the renderer reach it.

## Test plan

- [x] \`mise run test:file server/routes/apps.test.ts\` → 25 pass / 0 fail (6 new tests)
  - swarm-empty + deployment present → returns buildLogs
  - swarm non-empty + deployment present → swarm wins
  - swarm-empty + no deployment → empty string (existing contract preserved)
  - \`?tail=N\` truncates fallback to last N lines
  - \`?service=web\` falls back when swarm empty
  - multi-deployment → returns the one with latest \`createdAt\`
- [ ] _(post-merge)_ Redeploy prod fulcrum container on \`vctcn-app1\`; verify \`docker exec fulcrum fulcrum apps logs <running-app-id>\` returns the seeded 8-line compose-up content.

## Out of scope

- Pagination beyond \`tail\`.
- Streaming logs endpoint (\`/deploy/stream\` / \`/deploy/watch\`).
- Surfacing \`deployments.errorMessage\` in the same endpoint.

🤖 via [HAPI](https://hapi.run)