### PR TITLE
fix(ci): 让 vctcn CI job 使用 GitHub job container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: bun install
 
       - name: Run lint with auto-fix
-        run: bunx eslint . --fix
+        run: NODE_OPTIONS='--max-old-space-size=3072' bunx eslint frontend/ server/ cli/src/ shared/ plugins/ --fix
 
       - name: Commit lint fixes
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -45,6 +45,7 @@ jobs:
 
   test:
     name: Test
+    needs: check
     runs-on: [self-hosted, linux, vctcn]
     container:
       image: catthehacker/ubuntu:act-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   check:
     name: Lint & Typecheck
     runs-on: [self-hosted, linux, vctcn]
+    container:
+      image: catthehacker/ubuntu:full-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +46,8 @@ jobs:
   test:
     name: Test
     runs-on: [self-hosted, linux, vctcn]
+    container:
+      image: catthehacker/ubuntu:full-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint & Typecheck
     runs-on: [self-hosted, linux, vctcn]
     container:
-      image: catthehacker/ubuntu:full-24.04
+      image: catthehacker/ubuntu:act-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, vctcn]
     container:
-      image: catthehacker/ubuntu:full-24.04
+      image: catthehacker/ubuntu:act-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #258

## 摘要

让 fulcrum 的 vctcn CI 在 GitHub job container 里运行，并把 lint/test 串行化，避免同一 4GiB VM 上两个重依赖 container 同时安装造成 OOM。

## 意图

本 PR 只关闭 #258：把 fulcrum 作为 #151/#156 的真实 app workflow 验证入口。GARM pool 本身由 pve-vctcn#157 处理。

## 变更预演（Layer 1）

不适用——这是 GitHub Actions workflow 代码变更，没有声明式 dry-run target。变更预览用 diff 覆盖：

```text
.github/workflows/ci.yml | 7 ++++++-
```

## 落地核对（Layer 2）

落地 workflow 片段：

```text
13:    container:
14:      image: catthehacker/ubuntu:act-24.04
33:        run: NODE_OPTIONS='--max-old-space-size=3072' bunx eslint frontend/ server/ cli/src/ shared/ plugins/ --fix
48:    needs: check
50:    container:
51:      image: catthehacker/ubuntu:act-24.04
```

分析：两个 job 都声明同一个 cached job image；lint 限定 eslint 目标和 Node heap，test 通过 `needs: check` 等 lint/typecheck 完再跑，避免同机并发争资源。

## 启动 / 运行时顺序（Layer 3）

CI run `26448857697` 的 job 顺序和 container 初始化：

```text
Lint & Typecheck: Initialize containers 2026-05-26T12:51:27Z -> 12:51:30Z success
Test: needs check 后启动；Initialize containers 2026-05-26T12:57:01Z -> 12:57:02Z success
```

分析：`needs: check` 生效后 Test 在 Lint & Typecheck 成功后才开始，且两个 job 的 job container 都能初始化。

## 端到端业务行为（Layer 4）

真实 PR workflow 成功：

```text
run: https://github.com/moat-lab/fulcrum/actions/runs/26448857697
headSha: 013e0600ba4d9fd487137eabe123de6f6c92b71a
Lint & Typecheck: success
  Run lint with auto-fix: success
  Run typecheck: success
Test: success
  Install dependencies: success
  Run tests: success
```

分析：这不是只验证 YAML 语法；真实 vctcn runner 在 job container 内完成依赖安装、lint/typecheck 和 test，覆盖 #258 的期望行为。

## Analysis

观察到的 CI 顺序、container 初始化和最终 check 状态都符合 #258：fulcrum 的 vctcn CI 已经从宿主 runner 迁到 GitHub job container。之前失败的并发/OOM 路径通过 `needs: check` 和更窄 eslint 命令处理；没有这份 run 证据会漏掉 runner 能建容器但业务步骤被资源竞争杀掉的情况。
