### PR TITLE
ci(deploy): 改走 vctcn 私有 registry 发布链

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,32 +9,40 @@ on:
 jobs:
   build:
     name: Build and push image
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
+    runs-on: [self-hosted, linux, vctcn, netbird]
     outputs:
       image_tag: ${{ steps.meta.outputs.tag }}
+    env:
+      REGISTRY: registry.237575.xyz
+      IMAGE: registry.237575.xyz/fulcrum/app
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          driver-opts: network=host
 
       - name: Resolve image tag
         id: meta
         run: |
-          owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
-          echo "owner_lc=${owner_lc}" | tee -a "$GITHUB_OUTPUT"
-          echo "tag=ghcr.io/${owner_lc}/fulcrum:${{ github.sha }}" | tee -a "$GITHUB_OUTPUT"
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::12}"
+          echo "tag=${IMAGE}:${GITHUB_SHA}" | tee -a "$GITHUB_OUTPUT"
+          echo "short_tag=${IMAGE}:${short_sha}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Get Keycloak access token
+        id: registry-token
+        uses: Mouriya-Emma/keycloak-token-action@v1
+        with:
+          keycloak-url: https://keycloak.237575.xyz
+          realm: registry
+          client-id: registry
+          client-secret: ${{ secrets.REGISTRY_KEYCLOAK_CLIENT_SECRET }}
+
+      - name: Login to registry.237575.xyz
+        run: echo "${{ steps.registry-token.outputs.access-token }}" | docker login "$REGISTRY" -u sa-registry --password-stdin
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -43,14 +51,20 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tag }}
-            ghcr.io/${{ steps.meta.outputs.owner_lc }}/fulcrum:latest
+            ${{ steps.meta.outputs.short_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Pull verification
+        run: |
+          set -euo pipefail
+          docker pull "${{ steps.meta.outputs.tag }}"
+          docker image inspect "${{ steps.meta.outputs.tag }}" >/dev/null
 
   deploy:
     name: Deploy Komodo stack
     needs: build
-    runs-on: [self-hosted, linux, vctcn]
+    runs-on: [self-hosted, linux, vctcn, netbird]
     steps:
       - name: Komodo UpdateStack — pin image tag
         env:


### PR DESCRIPTION
Closes #268

## 摘要

把 Fulcrum deploy 的 build job 从 `ubuntu-latest` + GHCR 改为 vctcn GARM runner + Keycloak token + `registry.237575.xyz/fulcrum/app`，并加入 push 后 pull/inspect。

## 变更预演（Layer 1）

不适用——workflow 代码变更，无声明式 dry-run target。

## 落地核对（Layer 2）

```text
git diff --check
yq e . .github/workflows/deploy.yml >/dev/null
gh secret list -R moat-lab/fulcrum
# contains REGISTRY_KEYCLOAK_CLIENT_SECRET
```

分析：workflow 可解析，Fulcrum repo 已配置 registry Keycloak client secret。

## 启动 / 运行时顺序（Layer 3）

不适用——PR 改 CI build/publish path；服务启动顺序仍由 Komodo DeployStack 管理。

## 端到端业务行为（Layer 4）

```text
ssh root@vctcn-runner.mouriya.lan "docker exec garm garm-cli --format json pool show ba8571d7-6c49-4ed1-ae1d-a4e1fe57202b"
# observed: moat-lab/fulcrum flavor=docker labels=linux,netbird,self-hosted,vctcn,x64 min_idle=0 timeout=60
```

分析：目标 workflow labels 有 live GARM docker pool 承接；私有 registry 登录所需 secret 已配置。

## Analysis

Fulcrum deploy 现在符合 local-cicd 的私有 registry publish 形态，Komodo 接收的是 `registry.237575.xyz` image tag。没有这个修复，Fulcrum 会继续绕过标准 registry/root-of-trust 路径。