### PR TITLE
让 DeployStack workflow 验证真实终态

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,28 +73,80 @@ jobs:
           KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
           IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
+          set -euo pipefail
+          stack=$(curl -fsS -X POST "${KOMODO_URL}/read" \
+            -H "x-api-key: ${KOMODO_API_KEY}" \
+            -H "x-api-secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d '{"type":"GetStack","params":{"stack":"fulcrum"}}')
+          current_environment=$(jq -r '.config.environment // ""' <<<"$stack")
+          environment=$(
+            sed '/^FULCRUM_VERSION=/d' <<<"$current_environment"
+            printf 'FULCRUM_VERSION=%s\n' "$IMAGE_TAG"
+          )
+
           curl -fsS -X POST "${KOMODO_URL}/write" \
             -H "x-api-key: ${KOMODO_API_KEY}" \
             -H "x-api-secret: ${KOMODO_API_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "$(jq -n --arg tag "$IMAGE_TAG" '{
+            -d "$(jq -n --arg environment "$environment" '{
               type: "UpdateStack",
               params: {
                 id: "fulcrum",
                 config: {
-                  environment: ("FULCRUM_VERSION=" + $tag)
+                  environment: $environment
                 }
               }
             }')"
 
-      - name: Komodo DeployStack
+      - name: Komodo DeployStack — wait for terminal success
         env:
           KOMODO_URL: http://moat-app1.mouriya.lan:9120
           KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
           KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
-          curl -fsS -X POST "${KOMODO_URL}/execute" \
+          set -euo pipefail
+          response=$(curl -fsS -X POST "${KOMODO_URL}/execute" \
             -H "x-api-key: ${KOMODO_API_KEY}" \
             -H "x-api-secret: ${KOMODO_API_SECRET}" \
             -H "Content-Type: application/json" \
-            -d '{"type":"DeployStack","params":{"stack":"fulcrum"}}'
+            -d '{"type":"DeployStack","params":{"stack":"fulcrum"}}')
+          update_id=$(jq -er '._id."$oid"' <<<"$response")
+          echo "DeployStack update id: $update_id"
+
+          while true; do
+            update=$(curl -fsS -X POST "${KOMODO_URL}/read" \
+              -H "x-api-key: ${KOMODO_API_KEY}" \
+              -H "x-api-secret: ${KOMODO_API_SECRET}" \
+              -H "Content-Type: application/json" \
+              -d "{\"type\":\"GetUpdate\",\"params\":{\"id\":\"${update_id}\"}}")
+            status=$(jq -er '.status' <<<"$update")
+            success=$(jq -er '.success' <<<"$update")
+            echo "DeployStack status=$status success=$success"
+
+            case "$status" in
+              Complete)
+                jq . <<<"$update"
+                test "$success" = true
+                break
+                ;;
+              InProgress|Queued)
+                sleep 2
+                ;;
+              *)
+                jq . <<<"$update" >&2
+                echo "::error::DeployStack reached unexpected terminal state: $status" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          stack=$(curl -fsS -X POST "${KOMODO_URL}/read" \
+            -H "x-api-key: ${KOMODO_API_KEY}" \
+            -H "x-api-secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d '{"type":"GetStack","params":{"stack":"fulcrum"}}')
+          deployed_image=$(jq -er '.info.deployed_services[] | select(.service_name == "fulcrum") | .image' <<<"$stack")
+          test "$deployed_image" = "$IMAGE_TAG"
+          echo "Verified deployed image: $deployed_image"


### PR DESCRIPTION
Closes #271

## 摘要

让发布 workflow 在保留 Stack 其他 environment 条目后只替换 `FULCRUM_VERSION`，再轮询 Komodo `GetUpdate` 到 terminal state，并核对 `GetStack.info.deployed_services` 的实际镜像等于本次构建 tag。异步请求失败不再被记录成绿色部署。

## 变更预演（Layer 1）

```text
1 file changed, 43 insertions(+), 3 deletions(-)
```

保留现有单一 build/push artifact authority；更新镜像 tag 时先读取并保留 ResourceSync 注入的 secret environment，只替换 `FULCRUM_VERSION`。

## 落地核对（Layer 2）

```text
$ actionlint .github/workflows/deploy.yml
仅报告 repo 既有自托管 labels vctcn/netbird 未登记；无 workflow/shell 语法错误
$ git diff --check
(exit 0)
```

状态处理仅接受 `InProgress|Queued|Complete`；unexpected state 和 `Complete + success=false` 都会 noisy fail。

## 启动 / 运行时顺序（Layer 3）

```text
build/push → UpdateStack(FULCRUM_VERSION) → DeployStack
→ GetUpdate loop → Complete/success=true
→ GetStack deployed image exact assertion
```

不使用固定等待上限或匿名 digest auto-update，直接以 Komodo 持久 update 状态为完成条件。

## 端到端业务行为（Layer 4）

现有 run `27178222259` 返回 `DeployStack status=InProgress` 后立即 green；当前 Stack config 已是 `registry.237575.xyz/...:47a9c...`，线上容器却仍是 `ghcr.io/...:1a87e2c...`。本 PR 合并前先由 `homelab-tf#421` 给 Stack 绑定私有 registry account；随后真实 workflow dispatch 必须验证本地 registry 镜像落地，证据回填下游 IaC PR。

## Analysis

旧 workflow 只证明 Core 接受异步请求，不证明 pull/recreate 成功，正是配置与运行镜像分裂的根因。新增 terminal polling 与 exact-image assertion 后，这类私有 registry pull 失败会直接使 workflow 失败，不能再伪装成发布成功。
