### PR TITLE
用 base64 单行契约传递 SSH private key

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 mkdir -p /data/.fulcrum /data/.ssh
 chmod 700 /data/.ssh
 
-if [ -n "${FULCRUM_SSH_PRIVATE_KEY:-}" ]; then
+if [ -n "${FULCRUM_SSH_PRIVATE_KEY_BASE64:-}" ]; then
   umask 077
-  printf '%s\n' "$FULCRUM_SSH_PRIVATE_KEY" > /data/.ssh/id_ed25519
+  printf '%s' "$FULCRUM_SSH_PRIVATE_KEY_BASE64" \
+    | base64 --decode > /data/.ssh/id_ed25519
   chmod 600 /data/.ssh/id_ed25519
 fi
 


### PR DESCRIPTION
Closes #273

## 摘要

用单行 `FULCRUM_SSH_PRIVATE_KEY_BASE64` 替代 multiline raw-key 环境契约，entrypoint 严格 decode 到持久 `/data/.ssh/id_ed25519` 并保持 mode 0600。

## 变更预演（Layer 1）

```text
entrypoint.sh | 5 +++--
$ bash -n entrypoint.sh
(exit 0)
```

删除 raw-key 消费路径，不保留双格式兼容分支。

## 落地核对（Layer 2）

真实 `debian:bookworm-slim` 容器挂载 entrypoint 与空 `/data`，输入两行 fixture 的 base64 后，落盘内容逐字相等且 `stat -c %a=600`。

## 启动 / 运行时顺序（Layer 3）

entrypoint 先创建 0700 `.ssh` 目录，再以 077 umask decode/write/chmod，完成后才启动 rexecd 与主进程。Decode 失败发生在任何子进程启动前。

## 端到端业务行为（Layer 4）

```text
valid base64 decoded with mode 600
base64: invalid input
malformed base64 rejected
```

真实 shell/container 路径证明正例落盘和反例 noisy fail；`homelab-tf#421` 随后以生产 key checksum 与远程 SSH 业务路径验证 live delivery。

## Analysis

Komodo Variable 拒绝 multiline private key，单行 base64 是明确的跨系统边界类型，不是宽松 fallback。Malformed 输入直接阻止容器启动，避免写出损坏 key 后继续运行成半可用状态。
