### PR TITLE
统一 Fulcrum 镜像版本 authority

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,49 @@ jobs:
           IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
           set -euo pipefail
+          variable_response="$RUNNER_TEMP/fulcrum-version-variable.json"
+          get_variable=$(jq -nc '{
+            type: "GetVariable",
+            params: { name: "FULCRUM_VERSION" }
+          }')
+          status=$(curl -sS -o "$variable_response" -w '%{http_code}' \
+            -X POST "${KOMODO_URL}/read" \
+            -H "x-api-key: ${KOMODO_API_KEY}" \
+            -H "x-api-secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "$get_variable")
+
+          case "$status" in
+            200)
+              variable_write=$(jq -nc --arg value "$IMAGE_TAG" '{
+                type: "UpdateVariableValue",
+                params: { name: "FULCRUM_VERSION", value: $value }
+              }')
+              ;;
+            404|500)
+              variable_write=$(jq -nc --arg value "$IMAGE_TAG" '{
+                type: "CreateVariable",
+                params: {
+                  name: "FULCRUM_VERSION",
+                  value: $value,
+                  is_secret: false
+                }
+              }')
+              ;;
+            *)
+              cat "$variable_response" >&2
+              echo "::error::GetVariable FULCRUM_VERSION returned HTTP $status" >&2
+              exit 1
+              ;;
+          esac
+
+          curl -fsS -X POST "${KOMODO_URL}/write" \
+            -H "x-api-key: ${KOMODO_API_KEY}" \
+            -H "x-api-secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "$variable_write" >/dev/null
+          echo "Updated Komodo Variable FULCRUM_VERSION=$IMAGE_TAG"
+
           stack=$(curl -fsS -X POST "${KOMODO_URL}/read" \
             -H "x-api-key: ${KOMODO_API_KEY}" \
             -H "x-api-secret: ${KOMODO_API_SECRET}" \


### PR DESCRIPTION
Closes #275

## 摘要

让发布 workflow 在部署前把同一不可变镜像 tag 写入 Komodo `FULCRUM_VERSION` Variable，使直接 DeployStack 与 ResourceSync 共用发布版本 authority。

## 变更预演（Layer 1）

```text
yq eval '.' .github/workflows/deploy.yml >/dev/null
 yaml=ok
```

workflow YAML 可解析；diff 只扩展现有 UpdateStack 步骤，不改变构建产物或终态轮询。

## 落地核对（Layer 2）

```text
UpdateVariableValue / CreateVariable: name=FULCRUM_VERSION, value=$IMAGE_TAG
```

存在变量时精确更新；首次运行时创建非 secret Variable；任何非预期 HTTP 状态直接失败。

## 启动 / 运行时顺序（Layer 3）

真实 branch workflow `29078920521` 依次完成 build/push、Variable 写入、UpdateStack、DeployStack 终态轮询：

```text
Updated Komodo Variable FULCRUM_VERSION=registry.237575.xyz/fulcrum/app:7799b1e231d2e91c16e8fa596f4fd332aadb7b8a
DeployStack status=InProgress success=true
DeployStack status=InProgress success=true
DeployStack status=InProgress success=true
DeployStack status=Complete success=true
```

版本发布先于部署，且 workflow 没有在 `InProgress` 提前返回成功。

## 端到端业务行为（Layer 4）

```text
Verified deployed image: registry.237575.xyz/fulcrum/app:7799b1e231d2e91c16e8fa596f4fd332aadb7b8a
```

真实 Komodo 部署终态的镜像与本次 workflow 写入 Variable 的完整 SHA tag 完全一致；后续 homelab-apps PR 将让 ResourceSync 读取同一 Variable 并验证 RunSync 不回退。

## Analysis

branch workflow 已真实写入 Variable 并部署同一镜像，满足发布 workflow 唯一选择版本的约束。终态轮询和精确镜像断言仍生效；如果只验证 YAML，会漏掉 Komodo Variable API 的真实 create/update 语义。
